### PR TITLE
Fixes application not reconnecting as well as random crashing.

### DIFF
--- a/Relay/EASession+Streams.m
+++ b/Relay/EASession+Streams.m
@@ -15,7 +15,7 @@
 
 - (void)closeStreams {
     [self.inputStream closeStream];
-    [self.inputStream closeStream];
+    [self.outputStream closeStream];
 }
 
 @end

--- a/Relay/SDLTCPServer.m
+++ b/Relay/SDLTCPServer.m
@@ -129,10 +129,9 @@ static void openConnection(CFSocketRef socket, CFSocketCallBackType type, CFData
 
 - (void)sdl_processIncomingBytesForStream:(NSStream *)theStream {
     uint8_t buf[1024];
-    NSUInteger len = 0;
+    NSInteger len = 0;
     len = [(NSInputStream *)theStream read:buf maxLength:1024];
-    if (len) {
-        [data appendBytes:(const void *)buf length:len];
+    if (len > 0) {
         NSData* data = [NSData dataWithBytes:buf length:len];
 
         [self.delegate TCPServer:self didReceiveData:data];

--- a/Relay/SDLTCPServer.m
+++ b/Relay/SDLTCPServer.m
@@ -43,7 +43,7 @@
 - (void)startServer {
     CFSocketContext context = {0, (__bridge void *)self, NULL, NULL, NULL};
 
-    _socket = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_STREAM, IPPROTO_TCP, kCFSocketAcceptCallBack, &openConnection, &context);
+    self.socket = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_STREAM, IPPROTO_TCP, kCFSocketAcceptCallBack, &openConnection, &context);
 
     SDLTCPConnection* connection = [SDLTCPConnection connection];
     
@@ -56,15 +56,15 @@
     sin.sin_addr.s_addr = INADDR_ANY;
 
     // allow address/port to be reused after server is closed and restarted
-    setsockopt(CFSocketGetNative(_socket), SOL_SOCKET, SO_REUSEADDR, &(int){1}, sizeof(int));
-    setsockopt(CFSocketGetNative(_socket), SOL_SOCKET, SO_REUSEPORT, &(int){1}, sizeof(int));
+    setsockopt(CFSocketGetNative(self.socket), SOL_SOCKET, SO_REUSEADDR, &(int){1}, sizeof(int));
+    setsockopt(CFSocketGetNative(self.socket), SOL_SOCKET, SO_REUSEPORT, &(int){1}, sizeof(int));
 
     CFDataRef sincfd = CFDataCreate(kCFAllocatorDefault, (UInt8 *)&sin, sizeof(sin));
 
-    CFSocketSetAddress(_socket, sincfd);
+    CFSocketSetAddress(self.socket, sincfd);
     CFRelease(sincfd);
 
-    CFRunLoopSourceRef socketSource = CFSocketCreateRunLoopSource(kCFAllocatorDefault, _socket, 0);
+    CFRunLoopSourceRef socketSource = CFSocketCreateRunLoopSource(kCFAllocatorDefault, self.socket, 0);
     CFRunLoopAddSource(CFRunLoopGetCurrent(), socketSource, kCFRunLoopDefaultMode);
 
     [self.delegate TCPServer:self hasAvailableConnection:connection];
@@ -94,10 +94,10 @@ static void openConnection(CFSocketRef socket, CFSocketCallBackType type, CFData
     [self.inputStream closeStream];
     [self.outputStream closeStream];
 
-    if (_socket) {
-        CFSocketInvalidate(_socket);
-        CFRelease(_socket);
-        _socket = nil;
+    if (self.socket) {
+        CFSocketInvalidate(self.socket);
+        CFRelease(self.socket);
+        self.socket = nil;
     }
 }
 
@@ -128,12 +128,12 @@ static void openConnection(CFSocketRef socket, CFSocketCallBackType type, CFData
 }
 
 - (void)sdl_processIncomingBytesForStream:(NSStream *)theStream {
-    NSMutableData* data = [NSMutableData data];
     uint8_t buf[1024];
     NSUInteger len = 0;
     len = [(NSInputStream *)theStream read:buf maxLength:1024];
     if (len) {
         [data appendBytes:(const void *)buf length:len];
+        NSData* data = [NSData dataWithBytes:buf length:len];
 
         [self.delegate TCPServer:self didReceiveData:data];
     }

--- a/Relay/SDLiAPManager.m
+++ b/Relay/SDLiAPManager.m
@@ -148,11 +148,11 @@ static NSString* const LegacyProtocolString = @"com.ford.sync.prot0";
         NSInteger len = 0;
         len = [(NSInputStream *)aStream read:buf maxLength:1024];
 
-                NSMutableData *incomingEAData = [[NSMutableData alloc] init];
-                [incomingEAData appendBytes:(const void *)buf length:len];
-
-                [self.delegate iAPManager:self didReceiveData:incomingEAData];
+        if (len > 0) {
             if (self.protocolRerouted) {
+                NSData* incomingData = [NSData dataWithBytes:buf length:len];
+                
+                [self.delegate iAPManager:self didReceiveData:incomingData];
             } else {
                 NSData *recBytes = [[NSData alloc] initWithBytes:buf length:len];
                 int protocol = CFSwapInt32LittleToHost(*(int *)([recBytes bytes]));

--- a/Relay/SDLiAPManager.m
+++ b/Relay/SDLiAPManager.m
@@ -144,19 +144,18 @@ static NSString* const LegacyProtocolString = @"com.ford.sync.prot0";
 
 - (void)sdl_processIncomingBytesForStream:(NSStream *)aStream {
     while ([_session.inputStream hasBytesAvailable]) {
-        NSMutableData *incomingEAData = nil;
         uint8_t buf[1024];
-        NSUInteger len = 0;
+        NSInteger len = 0;
         len = [(NSInputStream *)aStream read:buf maxLength:1024];
-        NSData *recBytes = [[NSData alloc] initWithBytes:buf length:len];
 
         if (len) {
             if (_protocolRerouted) {
-                incomingEAData = [[NSMutableData alloc] init];
+                NSMutableData *incomingEAData = [[NSMutableData alloc] init];
                 [incomingEAData appendBytes:(const void *)buf length:len];
 
                 [self.delegate iAPManager:self didReceiveData:incomingEAData];
             } else {
+                NSData *recBytes = [[NSData alloc] initWithBytes:buf length:len];
                 int protocol = CFSwapInt32LittleToHost(*(int *)([recBytes bytes]));
                 NSString *newProtocol = [NSString stringWithFormat:IndexedProtocolString, protocol];
                 [self sdl_closeSession];


### PR DESCRIPTION
Fixes #1 

This PR is **ready** for review.
### Risk

This PR makes **no** API changes.
### Testing Plan

Disconnect and reconnect an application over TCP/IP multiple times, as well as disconnecting the proxy and reconnecting then connecting an application.
### Summary

This PR fixes an issue with applications not being able to reconnect. We also found an issue with applications crashing in a specific, reproducible incident.
1. Start Relay.
2. Connect to Core.
3. Force close Relay.
4. Reopen Relay.
5. Disconnect Relay.
6. Reconnect Relay.
7. Connect app to Relay.
8. Crash.
### Changelog
##### Bug Fixes
- Fixed `EASession`'s category that was mistyped, which never closed the output stream.
- Fixed issue with application randomly crashing because the read of `NSStream` was returning back -1 and we were still trying to read.
